### PR TITLE
Add asynchronous message handling

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     implementation("ai.fal.client:fal-client:0.7.1")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.awaitility:awaitility:4.2.0")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/src/main/java/com/github/beothorn/telegramAIConnector/telegram/ProcessingStatus.java
+++ b/src/main/java/com/github/beothorn/telegramAIConnector/telegram/ProcessingStatus.java
@@ -1,0 +1,56 @@
+package com.github.beothorn.telegramAIConnector.telegram;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProcessingStatus {
+
+    private final Map<Long, Map<Future<?>, String>> running = new ConcurrentHashMap<>();
+
+    public void register(
+        final Long chatId,
+        final Future<?> future,
+        final String description
+    ) {
+        running.computeIfAbsent(chatId, id -> new ConcurrentHashMap<>())
+            .put(future, description);
+    }
+
+    public void unregister(
+        final Long chatId,
+        final Future<?> future
+    ) {
+        final Map<Future<?>, String> futures = running.get(chatId);
+        if (futures == null) {
+            return;
+        }
+        futures.remove(future);
+        if (futures.isEmpty()) {
+            running.remove(chatId);
+        }
+    }
+
+    public String status(
+        final Long chatId
+    ) {
+        final Map<Future<?>, String> futures = running.get(chatId);
+        if (futures == null || futures.isEmpty()) {
+            return "I'm not doing anything.";
+        }
+
+        futures.entrySet().removeIf(entry -> entry.getKey().isDone());
+        if (futures.isEmpty()) {
+            running.remove(chatId);
+            return "I'm not doing anything.";
+        }
+
+        return futures.values().stream()
+            .map(desc -> "Processing: " + desc)
+            .collect(Collectors.joining("\n"));
+    }
+}

--- a/src/main/java/com/github/beothorn/telegramAIConnector/telegram/TelegramAiBot.java
+++ b/src/main/java/com/github/beothorn/telegramAIConnector/telegram/TelegramAiBot.java
@@ -5,23 +5,14 @@ import com.github.beothorn.telegramAIConnector.ai.tools.SystemTools;
 import com.github.beothorn.telegramAIConnector.auth.Authentication;
 import com.github.beothorn.telegramAIConnector.tasks.TaskScheduler;
 import com.github.beothorn.telegramAIConnector.user.UserRepository;
+import com.github.beothorn.telegramAIConnector.utils.InstantUtils;
+import jakarta.annotation.PreDestroy;
 import org.apache.logging.log4j.util.Strings;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-
-import com.github.beothorn.telegramAIConnector.telegram.ProcessingStatus;
-import jakarta.annotation.PreDestroy;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 import org.telegram.telegrambots.client.okhttp.OkHttpTelegramClient;
 import org.telegram.telegrambots.longpolling.util.LongPollingSingleThreadUpdateConsumer;
 import org.telegram.telegrambots.meta.api.methods.ActionType;
@@ -46,6 +37,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
+import java.util.concurrent.*;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 @Component
@@ -517,7 +510,7 @@ public class TelegramAiBot implements LongPollingSingleThreadUpdateConsumer {
         logger.info("Consume text from {}: {}", chatId, text);
         runAsync(
             chatId,
-            "message",
+            "message" + InstantUtils.currentTimeSeconds(),
             () -> {
                 final TelegramTools telegramTools = getTelegramTools(chatId);
                 return aiBotService.prompt(chatId, text, telegramTools, new SystemTools());
@@ -534,7 +527,7 @@ public class TelegramAiBot implements LongPollingSingleThreadUpdateConsumer {
         final String text = "SystemAction: User upload file to '" + uploadedFileString + "'.";
         runAsync(
             chatId,
-            "file",
+            "file" + InstantUtils.currentTimeSeconds(),
             () -> {
                 final TelegramTools telegramTools = getTelegramTools(chatId);
                 return aiBotService.prompt(chatId, text, telegramTools, new SystemTools());
@@ -551,7 +544,7 @@ public class TelegramAiBot implements LongPollingSingleThreadUpdateConsumer {
         final String locationMessage = String.format("TelegramAction: User shared a location %f %f", latitude, longitude);
         runAsync(
             chatId,
-            "location",
+            "location" + InstantUtils.currentTimeSeconds(),
             () -> {
                 final TelegramTools telegramTools = getTelegramTools(chatId);
                 return aiBotService.prompt(chatId, locationMessage, telegramTools, new SystemTools());

--- a/src/main/java/com/github/beothorn/telegramAIConnector/utils/InstantUtils.java
+++ b/src/main/java/com/github/beothorn/telegramAIConnector/utils/InstantUtils.java
@@ -26,4 +26,10 @@ public class InstantUtils {
         LocalDateTime localDateTime = LocalDateTime.ofInstant(Instant.now(), ZoneId.systemDefault());
         return localDateTime.format(formatter);
     }
+
+    public static String currentTimeSeconds() {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd_HH:mm_ss");
+        LocalDateTime localDateTime = LocalDateTime.ofInstant(Instant.now(), ZoneId.systemDefault());
+        return localDateTime.format(formatter);
+    }
 }

--- a/src/test/java/com/github/beothorn/telegramAIConnector/telegram/ProcessingStatusTest.java
+++ b/src/test/java/com/github/beothorn/telegramAIConnector/telegram/ProcessingStatusTest.java
@@ -1,0 +1,72 @@
+package com.github.beothorn.telegramAIConnector.telegram;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+public class ProcessingStatusTest {
+
+    @Test
+    void registerShowsStatusUntilThreadEnds() {
+        final ProcessingStatus status = new ProcessingStatus();
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        final Future<?> future = executor.submit(() -> {
+            try {
+                Thread.sleep(200);
+            } catch (final InterruptedException ignored) {
+            }
+        });
+
+        status.register(1L, future, "working");
+
+        assertTrue(status.status(1L).contains("working"));
+
+        Awaitility.await().atMost(Duration.ofSeconds(1)).until(future::isDone);
+        status.unregister(1L, future);
+
+        assertEquals("I'm not doing anything.", status.status(1L));
+        executor.shutdown();
+    }
+
+    @Test
+    void multipleThreadsKeepIndependentStatuses() {
+        final ProcessingStatus status = new ProcessingStatus();
+        final ExecutorService executor = Executors.newFixedThreadPool(2);
+        final Future<?> f1 = executor.submit(() -> {
+            try {
+                Thread.sleep(200);
+            } catch (final InterruptedException ignored) {
+            }
+        });
+        final Future<?> f2 = executor.submit(() -> {
+            try {
+                Thread.sleep(400);
+            } catch (final InterruptedException ignored) {
+            }
+        });
+
+        status.register(1L, f1, "one");
+        status.register(1L, f2, "two");
+
+        assertTrue(status.status(1L).contains("one"));
+        assertTrue(status.status(1L).contains("two"));
+
+        Awaitility.await().atMost(Duration.ofSeconds(1)).until(f1::isDone);
+        status.unregister(1L, f1);
+        final String current = status.status(1L);
+        assertFalse(current.contains("one"));
+        assertTrue(current.contains("two"));
+
+        Awaitility.await().atMost(Duration.ofSeconds(1)).until(f2::isDone);
+        status.unregister(1L, f2);
+
+        assertEquals("I'm not doing anything.", status.status(1L));
+        executor.shutdown();
+    }
+}


### PR DESCRIPTION
## Summary
- implement ProcessingStatus registry to track running threads
- spawn asynchronous threads for messages in TelegramAiBot
- add `/doing` command to check current activity
- keep typing feedback while processing
- add ProcessingStatus tests and Awaitility dependency
- support multiple concurrent tasks
- use executor services for background work

## Testing
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_6849fe80623c832998045b4eed18d224