### PR TITLE
Enhance backoffice UI

### DIFF
--- a/src/main/java/com/github/beothorn/telegramAIConnector/backoffice/WebController.java
+++ b/src/main/java/com/github/beothorn/telegramAIConnector/backoffice/WebController.java
@@ -44,7 +44,15 @@ public class WebController {
     @GetMapping({"", "/"})
     public String index(Model model) {
         model.addAttribute("botName", telegramAiBot.getBotName());
-        model.addAttribute("conversations", messagesRepository.findConversationIds());
+        var conversationIds = messagesRepository.findConversationIds();
+        var conversationInfos = conversationIds.stream().map(id -> {
+            var user = userRepository.getUser(Long.parseLong(id));
+            if (user == null) {
+                return new com.github.beothorn.telegramAIConnector.user.UserInfo(Long.parseLong(id), "", "", "");
+            }
+            return user;
+        }).toList();
+        model.addAttribute("conversations", conversationInfos);
         model.addAttribute("tasks", taskRepository.getAll());
         return "backoffice";
     }

--- a/src/main/resources/static/backoffice.js
+++ b/src/main/resources/static/backoffice.js
@@ -1,5 +1,10 @@
 
 document.addEventListener('DOMContentLoaded', () => {
+  const autoResize = (textarea) => {
+    textarea.style.height = 'auto';
+    textarea.style.height = textarea.scrollHeight + 'px';
+  };
+
   const reloadMessages = async () => {
     const table = document.getElementById('messagesTable');
     if (!table) return;
@@ -29,6 +34,10 @@ document.addEventListener('DOMContentLoaded', () => {
       tbody.appendChild(tr);
     });
     tbody.querySelectorAll('form[data-fetch]').forEach(sendWithFetch);
+    tbody.querySelectorAll('textarea').forEach(t => {
+      autoResize(t);
+      t.addEventListener('input', () => autoResize(t));
+    });
   };
 
   const sendWithFetch = form => {
@@ -54,5 +63,9 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   document.querySelectorAll('form[data-fetch]').forEach(sendWithFetch);
+  document.querySelectorAll('textarea').forEach(t => {
+    autoResize(t);
+    t.addEventListener('input', () => autoResize(t));
+  });
 });
 

--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -51,6 +51,8 @@ input[type="text"] {
     background-color: var(--bg-color);
     color: var(--text-color);
     border: 1px solid var(--border-color);
+    overflow-y: hidden;
+    resize: vertical;
 }
 button {
     padding: 6px 12px;

--- a/src/main/resources/templates/backoffice.html
+++ b/src/main/resources/templates/backoffice.html
@@ -19,10 +19,14 @@
 <div class="section">
 <h2>Conversations</h2>
 <table>
-    <thead><tr><th>Chat Id</th></tr></thead>
+    <thead>
+    <tr><th>Chat Id</th><th>Name</th><th>Username</th></tr>
+    </thead>
     <tbody>
-    <tr th:each="chatId : ${conversations}">
-        <td><a th:href="@{|/backoffice/conversations/${chatId}|}" th:text="${chatId}"></a></td>
+    <tr th:each="u : ${conversations}">
+        <td><a th:href="@{|/backoffice/conversations/${u.chatId}|}" th:text="${u.chatId}"></a></td>
+        <td th:text="${u.firstName} + ' ' + ${u.lastName}"></td>
+        <td th:text="${u.username}"></td>
     </tr>
     </tbody>
 </table>


### PR DESCRIPTION
## Summary
- resize message text areas automatically
- prevent scrollbar for multi-line messages
- list contact name and username in conversations table

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_684db3dcdad08329989f279c99f53375