### PR TITLE
Add broadcast in backoffice and improve test docs

### DIFF
--- a/src/main/java/com/github/beothorn/telegramAIConnector/backoffice/Api.java
+++ b/src/main/java/com/github/beothorn/telegramAIConnector/backoffice/Api.java
@@ -74,6 +74,18 @@ public class Api {
     }
 
     /**
+     * Sends a plain text message to every known conversation.
+     *
+     * @param message text to broadcast
+     */
+    @PostMapping("/broadcast")
+    public void broadcast(@RequestParam("message") final String message) {
+        for (String id : messagesRepository.findConversationIds()) {
+            telegramAiBot.sendMessage(Long.parseLong(id), message);
+        }
+    }
+
+    /**
      * Sends an anonymous prompt to the bot.
      * This will use chat id 0.
      *

--- a/src/main/resources/templates/backoffice.html
+++ b/src/main/resources/templates/backoffice.html
@@ -17,6 +17,14 @@
 </div>
 
 <div class="section">
+<h2>Broadcast</h2>
+<form id="broadcastForm" action="/api/broadcast" method="post" data-fetch class="wide-form">
+    <textarea name="message" rows="3"></textarea>
+    <button type="submit">Send</button>
+</form>
+</div>
+
+<div class="section">
 <h2>Conversations</h2>
 <table>
     <thead>

--- a/src/test/java/com/github/beothorn/telegramAIConnector/backoffice/ApiTest.java
+++ b/src/test/java/com/github/beothorn/telegramAIConnector/backoffice/ApiTest.java
@@ -34,4 +34,25 @@ public class ApiTest {
         Api api = new Api(bot,tasks,messages,auth,profiles,files, users);
         assertEquals(List.of("1"), api.getConversationIds());
     }
+
+    /**
+     * Broadcasts a message to every chat id returned by the repository.
+     */
+    @Test
+    void broadcastDelegates() {
+        TelegramAiBot bot = mock(TelegramAiBot.class);
+        TaskRepository tasks = mock(TaskRepository.class);
+        MessagesRepository messages = mock(MessagesRepository.class);
+        Authentication auth = mock(Authentication.class);
+        UserProfileRepository profiles = mock(UserProfileRepository.class);
+        UserRepository users = mock(UserRepository.class);
+        FileService files = mock(FileService.class);
+
+        when(messages.findConversationIds()).thenReturn(List.of("1","2"));
+        Api api = new Api(bot,tasks,messages,auth,profiles,files, users);
+        api.broadcast("hi");
+
+        org.mockito.Mockito.verify(bot).sendMessage(1L, "hi");
+        org.mockito.Mockito.verify(bot).sendMessage(2L, "hi");
+    }
 }

--- a/src/test/java/com/github/beothorn/telegramAIConnector/telegram/TelegramToolsTest.java
+++ b/src/test/java/com/github/beothorn/telegramAIConnector/telegram/TelegramToolsTest.java
@@ -18,6 +18,9 @@ public class TelegramToolsTest {
     @TempDir
     Path tempDir;
 
+    /**
+     * Registers a reminder when the given date is in the future.
+     */
     @Test
     void sendReminderSchedulesWhenFutureDate() {
         TaskScheduler scheduler = mock(TaskScheduler.class);
@@ -31,6 +34,9 @@ public class TelegramToolsTest {
         verify(scheduler).schedule(eq(bot), eq(1L), eq("hello"), any(Instant.class));
     }
 
+    /**
+     * Rejects reminders scheduled for past dates.
+     */
     @Test
     void sendReminderRefusesPastDate() {
         TaskScheduler scheduler = mock(TaskScheduler.class);
@@ -44,6 +50,9 @@ public class TelegramToolsTest {
         verifyNoInteractions(scheduler);
     }
 
+    /**
+     * Sends a markdown message using the bot instance.
+     */
     @Test
     void sendMessageDelegatesToBot() throws Exception {
         TaskScheduler scheduler = mock(TaskScheduler.class);
@@ -55,6 +64,9 @@ public class TelegramToolsTest {
         verify(bot).sendMarkdownMessage(2L, "hello");
     }
 
+    /**
+     * Returns an error message when Telegram fails to send.
+     */
     @Test
     void sendMessageHandlesException() throws Exception {
         TaskScheduler scheduler = mock(TaskScheduler.class);
@@ -67,6 +79,9 @@ public class TelegramToolsTest {
         assertEquals("Could not send message, got error: 'boom'.", result);
     }
 
+    /**
+     * Delegates file sending to the bot.
+     */
     @Test
     void sendAsFileCallsBot() throws Exception {
         TaskScheduler scheduler = mock(TaskScheduler.class);
@@ -79,6 +94,9 @@ public class TelegramToolsTest {
         verify(bot).sendFileWithCaption(eq(3L), anyString(), contains("t.txt"));
     }
 
+    /**
+     * Saves content to a file and reads it back.
+     */
     @Test
     void saveAndReadFileWorks() throws Exception {
         TaskScheduler scheduler = mock(TaskScheduler.class);
@@ -92,6 +110,9 @@ public class TelegramToolsTest {
         assertEquals("data", content);
     }
 
+    /**
+     * Deletes an existing file from disk.
+     */
     @Test
     void deleteFileRemovesFile() throws Exception {
         TaskScheduler scheduler = mock(TaskScheduler.class);
@@ -105,6 +126,9 @@ public class TelegramToolsTest {
         assertEquals("The file 'a.txt' was deleted.", msg);
     }
 
+    /**
+     * Rejects deletion when the file path escapes the chat directory.
+     */
     @Test
     void deleteFileInvalidName() {
         TaskScheduler scheduler = mock(TaskScheduler.class);

--- a/src/test/java/com/github/beothorn/telegramAIConnector/user/MessagesRepositoryCrudTest.java
+++ b/src/test/java/com/github/beothorn/telegramAIConnector/user/MessagesRepositoryCrudTest.java
@@ -12,6 +12,9 @@ public class MessagesRepositoryCrudTest {
     @TempDir
     Path tempDir;
 
+    /**
+     * Stores a message, updates its content and then deletes it.
+     */
     @Test
     void insertUpdateDeleteMessage() {
         MessagesRepository repo = new MessagesRepository(50);

--- a/src/test/java/com/github/beothorn/telegramAIConnector/user/StoredMessageTest.java
+++ b/src/test/java/com/github/beothorn/telegramAIConnector/user/StoredMessageTest.java
@@ -5,6 +5,9 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class StoredMessageTest {
+    /**
+     * Ensures the record accessors return the stored values.
+     */
     @Test
     void recordValues() {
         StoredMessage m = new StoredMessage(1L,"user","hi","ts");

--- a/src/test/java/com/github/beothorn/telegramAIConnector/user/UserInfoTest.java
+++ b/src/test/java/com/github/beothorn/telegramAIConnector/user/UserInfoTest.java
@@ -5,6 +5,9 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class UserInfoTest {
+    /**
+     * Confirms all record getters return the constructor values.
+     */
     @Test
     void recordValues() {
         UserInfo info = new UserInfo(1L,"u","f","l");

--- a/src/test/java/com/github/beothorn/telegramAIConnector/user/UserRepositoryTest.java
+++ b/src/test/java/com/github/beothorn/telegramAIConnector/user/UserRepositoryTest.java
@@ -11,6 +11,9 @@ public class UserRepositoryTest {
     @TempDir
     Path tempDir;
 
+    /**
+     * Inserts a user record and updates it.
+     */
     @Test
     void createAndRetrieveUser() {
         UserRepository repo = new UserRepository();

--- a/src/test/java/com/github/beothorn/telegramAIConnector/user/profile/UserProfileRepositoryTest.java
+++ b/src/test/java/com/github/beothorn/telegramAIConnector/user/profile/UserProfileRepositoryTest.java
@@ -11,6 +11,9 @@ public class UserProfileRepositoryTest {
     @TempDir
     Path folder;
 
+    /**
+     * Persists and retrieves a profile for a user.
+     */
     @Test
     void setAndGet() {
         UserProfileRepository repo = new UserProfileRepository();

--- a/src/test/java/com/github/beothorn/telegramAIConnector/user/profile/advisors/UserProfileAdvisorTest.java
+++ b/src/test/java/com/github/beothorn/telegramAIConnector/user/profile/advisors/UserProfileAdvisorTest.java
@@ -18,6 +18,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 public class UserProfileAdvisorTest {
+    /**
+     * Ensures the advisor stores the profile returned by the AI model.
+     */
     @Test
     void adviseUpdatesProfile() {
         ChatModel model = mock(ChatModel.class);

--- a/src/test/java/com/github/beothorn/telegramAIConnector/utils/InstantUtilsTest.java
+++ b/src/test/java/com/github/beothorn/telegramAIConnector/utils/InstantUtilsTest.java
@@ -7,6 +7,9 @@ import java.time.Instant;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class InstantUtilsTest {
+    /**
+     * Checks that a formatted instant can be parsed back.
+     */
     @Test
     void formatAndParse() {
         Instant now = Instant.now();

--- a/src/test/java/com/github/beothorn/telegramAIConnector/utils/TelegramAIFileUtilsTest.java
+++ b/src/test/java/com/github/beothorn/telegramAIConnector/utils/TelegramAIFileUtilsTest.java
@@ -12,6 +12,9 @@ public class TelegramAIFileUtilsTest {
     @TempDir
     Path folder;
 
+    /**
+     * Validates that files outside the parent folder are detected.
+     */
     @Test
     void detectsOutsideFile() throws Exception {
         File parent = folder.toFile();

--- a/wiki/backoffice.md
+++ b/wiki/backoffice.md
@@ -8,6 +8,7 @@ and manage conversations, scheduled tasks, user profiles and uploaded files.
 Open `http://yourAddress:9996/backoffice` to access the index. The page shows:
 
 * A form to send anonymous prompts using the `/api/prompt` endpoint.
+* A form to broadcast a message to all known chats using `/api/broadcast`.
 * A table with the known conversation ids. Each id links to a conversation page and has a delete button.
 * A table listing all scheduled tasks stored in the database.
 


### PR DESCRIPTION
## Summary
- add broadcast endpoint in `Api`
- show broadcast form on backoffice
- document broadcast form in the wiki
- clarify scenarios in tests

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6851daa1dfac8329b40f2b08417dac9c