### PR TITLE
Support quoted arguments in commands

### DIFF
--- a/src/main/java/com/github/beothorn/telegramAIConnector/telegram/TelegramAiBot.java
+++ b/src/main/java/com/github/beothorn/telegramAIConnector/telegram/TelegramAiBot.java
@@ -8,6 +8,7 @@ import com.github.beothorn.telegramAIConnector.auth.Authentication;
 import com.github.beothorn.telegramAIConnector.tasks.TaskScheduler;
 import com.github.beothorn.telegramAIConnector.user.UserRepository;
 import com.github.beothorn.telegramAIConnector.utils.InstantUtils;
+import com.github.beothorn.telegramAIConnector.utils.CommandParser;
 import jakarta.annotation.PreDestroy;
 import org.apache.logging.log4j.util.Strings;
 import org.jetbrains.annotations.NotNull;
@@ -564,10 +565,12 @@ public class TelegramAiBot implements LongPollingSingleThreadUpdateConsumer {
             return;
         }
         if (command.equalsIgnoreCase("rename")) {
-            String[] tokens = args.split("\\s+", 2);
-            String firstArg = tokens[0];
-            String secondArg = tokens.length > 1 ? tokens[1] : firstArg;
-            sendMessage(chatId, commands.rename(chatId, firstArg, secondArg));
+            String[] tokens = CommandParser.parseTwoArguments(args);
+            if (Strings.isBlank(tokens[1])) {
+                sendMessage(chatId, "Usage: /rename \"old name\" \"new name\"");
+            } else {
+                sendMessage(chatId, commands.rename(chatId, tokens[0], tokens[1]));
+            }
             return;
         }
         if (command.equalsIgnoreCase("download")) {
@@ -578,9 +581,9 @@ public class TelegramAiBot implements LongPollingSingleThreadUpdateConsumer {
             if (Strings.isBlank(args)) {
                 sendMessage(chatId, "Usage: /analyzeImage fileName [prompt]");
             } else {
-                String[] tokens = args.split("\\s+", 2);
+                String[] tokens = CommandParser.parseTwoArguments(args);
                 String firstArg = tokens[0];
-                String secondArg = tokens.length > 1 ? tokens[1] : "Describe the image.";
+                String secondArg = Strings.isBlank(tokens[1]) ? "Describe the image." : tokens[1];
                 runAsync(
                     chatId,
                     "analyzeImage" + InstantUtils.currentTimeSeconds(),
@@ -601,9 +604,9 @@ public class TelegramAiBot implements LongPollingSingleThreadUpdateConsumer {
                 if (Strings.isBlank(args)) {
                     sendMessage(chatId, "Usage: /generateImage fileName [prompt]");
                 } else {
-                    String[] tokens = args.split("\\s+", 2);
+                    String[] tokens = CommandParser.parseTwoArguments(args);
                     String firstArg = tokens[0];
-                    String secondArg = tokens.length > 1 ? tokens[1] : "";
+                    String secondArg = Strings.isBlank(tokens[1]) ? "" : tokens[1];
                     runAsync(
                             chatId,
                             "generateImage" + InstantUtils.currentTimeSeconds(),

--- a/src/main/java/com/github/beothorn/telegramAIConnector/utils/CommandParser.java
+++ b/src/main/java/com/github/beothorn/telegramAIConnector/utils/CommandParser.java
@@ -1,0 +1,36 @@
+package com.github.beothorn.telegramAIConnector.utils;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parses command arguments supporting quoted strings.
+ */
+public class CommandParser {
+
+    private static final Pattern TOKEN_PATTERN = Pattern.compile("\"([^\"]*)\"|(\\S+)");
+
+    /**
+     * Splits an argument string into at most two tokens. Tokens can be quoted
+     * with double quotes to include spaces.
+     *
+     * @param args the raw arguments string
+     * @return an array with exactly two elements. Missing elements are empty strings.
+     */
+    public static String[] parseTwoArguments(final String args) {
+        String[] result = new String[]{"", ""};
+        if (args == null) {
+            return result;
+        }
+        Matcher matcher = TOKEN_PATTERN.matcher(args);
+        int i = 0;
+        while (matcher.find() && i < 2) {
+            String token = matcher.group(1) != null ? matcher.group(1) : matcher.group(2);
+            if (token == null) {
+                token = "";
+            }
+            result[i++] = token;
+        }
+        return result;
+    }
+}

--- a/src/test/java/com/github/beothorn/telegramAIConnector/utils/CommandParserTest.java
+++ b/src/test/java/com/github/beothorn/telegramAIConnector/utils/CommandParserTest.java
@@ -1,0 +1,32 @@
+package com.github.beothorn.telegramAIConnector.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+public class CommandParserTest {
+
+    @Test
+    void parsesQuotedArguments() {
+        String[] res = CommandParser.parseTwoArguments("\"foo bar.png\" \"bar baz.png\"");
+        assertArrayEquals(new String[]{"foo bar.png", "bar baz.png"}, res);
+    }
+
+    @Test
+    void handlesSingleQuotedArg() {
+        String[] res = CommandParser.parseTwoArguments("\"foo bar.png\" bar");
+        assertArrayEquals(new String[]{"foo bar.png", "bar"}, res);
+    }
+
+    @Test
+    void handlesMissingSecondArg() {
+        String[] res = CommandParser.parseTwoArguments("onearg");
+        assertArrayEquals(new String[]{"onearg", ""}, res);
+    }
+
+    @Test
+    void handlesEmptyInput() {
+        String[] res = CommandParser.parseTwoArguments("");
+        assertArrayEquals(new String[]{"", ""}, res);
+    }
+}


### PR DESCRIPTION
## Summary
- handle arguments with spaces using new `CommandParser`
- use quoting-aware parsing for `/rename`, `/analyzeImage` and `/generateImage`
- show usage message when `/rename` is missing arguments
- test edge cases for new parser

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685325b6d3948329a30fe7d2259d3032