### PR TITLE
Persist Telegram tool messages

### DIFF
--- a/src/main/java/com/github/beothorn/telegramAIConnector/telegram/Commands.java
+++ b/src/main/java/com/github/beothorn/telegramAIConnector/telegram/Commands.java
@@ -3,6 +3,7 @@ package com.github.beothorn.telegramAIConnector.telegram;
 import com.github.beothorn.telegramAIConnector.ai.tools.SystemTools;
 import com.github.beothorn.telegramAIConnector.tasks.TaskScheduler;
 import com.github.beothorn.telegramAIConnector.user.profile.UserProfileRepository;
+import com.github.beothorn.telegramAIConnector.user.MessagesRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.tool.ToolCallback;
@@ -28,6 +29,7 @@ public class Commands {
     private final ToolCallbackProvider toolCallbackProvider;
     private final String uploadFolder;
     private final UserProfileRepository userProfileRepository;
+    private final MessagesRepository messagesRepository;
 
     /**
      * Constructs a helper with the provided dependencies.
@@ -41,11 +43,13 @@ public class Commands {
             final TaskScheduler taskScheduler,
             final ToolCallbackProvider toolCallbackProvider,
             final UserProfileRepository userProfileRepository,
+            final MessagesRepository messagesRepository,
             @Value("${telegramIAConnector.uploadFolder}") final String uploadFolder
     ) {
         this.taskScheduler = taskScheduler;
         this.toolCallbackProvider = toolCallbackProvider;
         this.userProfileRepository = userProfileRepository;
+        this.messagesRepository = messagesRepository;
         this.uploadFolder = uploadFolder;
         this.systemTools = new SystemTools();
     }
@@ -86,7 +90,8 @@ public class Commands {
                 null,
                 taskScheduler,
                 chatId,
-                uploadFolder
+                uploadFolder,
+                messagesRepository
         );
         return telegramTools.listUploadedFiles();
     }
@@ -106,7 +111,8 @@ public class Commands {
                 null,
                 taskScheduler,
                 chatId,
-                uploadFolder
+                uploadFolder,
+                messagesRepository
         );
         return telegramTools.deleteFile(file);
     }
@@ -123,7 +129,8 @@ public class Commands {
                 null,
                 taskScheduler,
                 chatId,
-                uploadFolder
+                uploadFolder,
+                messagesRepository
         );
         return telegramTools.readFile(file);
     }
@@ -145,7 +152,8 @@ public class Commands {
                 null,
                 taskScheduler,
                 chatId,
-                uploadFolder
+                uploadFolder,
+                messagesRepository
         );
         return telegramTools.renameFile(oldFileName, newFileName);
     }
@@ -167,7 +175,8 @@ public class Commands {
                 telegramAiBot,
                 taskScheduler,
                 chatId,
-                uploadFolder
+                uploadFolder,
+                messagesRepository
         );
         return telegramTools.sendFile(args, "");
     }

--- a/src/main/java/com/github/beothorn/telegramAIConnector/telegram/TelegramAiBot.java
+++ b/src/main/java/com/github/beothorn/telegramAIConnector/telegram/TelegramAiBot.java
@@ -362,6 +362,9 @@ public class TelegramAiBot implements LongPollingSingleThreadUpdateConsumer {
             final String text = update.getMessage().getText();
 
             if (text.startsWith("/")) {
+                if (!text.startsWith("/login")) {
+                    messagesRepository.insertMessage(chatId.toString(), "user", text);
+                }
                 final String[] commandWithArgs = text.split("\\s+", 2);
                 String command = commandWithArgs[0].substring(1);
                 if (commandWithArgs.length == 1) {

--- a/src/main/java/com/github/beothorn/telegramAIConnector/telegram/TelegramAiBot.java
+++ b/src/main/java/com/github/beothorn/telegramAIConnector/telegram/TelegramAiBot.java
@@ -70,7 +70,7 @@ public class TelegramAiBot implements LongPollingSingleThreadUpdateConsumer {
     private final Logger logger = LoggerFactory.getLogger(TelegramAiBot.class);
 
     private void storeAssistantMessage(Long chatId, String message) {
-        if (messagesRepository != null && message != null && !message.isBlank()) {
+        if (message != null && !message.isBlank()) {
             messagesRepository.insertMessage(chatId.toString(), "assistant", message);
         }
     }

--- a/src/main/java/com/github/beothorn/telegramAIConnector/telegram/TelegramTools.java
+++ b/src/main/java/com/github/beothorn/telegramAIConnector/telegram/TelegramTools.java
@@ -111,9 +111,7 @@ public class TelegramTools {
     ) {
         try {
             telegramAiBot.sendMarkdownMessage(chatId, message);
-            if (messagesRepository != null) {
-                messagesRepository.insertMessage(Long.toString(chatId), "assistant", message);
-            }
+            messagesRepository.insertMessage(Long.toString(chatId), "assistant", message);
         } catch (TelegramApiException e) {
             return "Could not send message, got error: '" + e.getMessage() + "'.";
         }
@@ -145,7 +143,7 @@ public class TelegramTools {
         }
         try {
             telegramAiBot.sendFileWithCaption(chatId, file.getAbsolutePath(), caption);
-            if (messagesRepository != null && caption != null && !caption.isBlank()) {
+            if (caption != null && !caption.isBlank()) {
                 messagesRepository.insertMessage(Long.toString(chatId), "assistant", caption);
             }
             return "File '" + fileName + "' sent successfully.";
@@ -334,9 +332,7 @@ public class TelegramTools {
             Files.writeString(tempFile.toPath(), fileContents);
             String caption = "Here is your file: " + fileName;
             telegramAiBot.sendFileWithCaption(chatId, tempFile.getAbsolutePath(), caption);
-            if (messagesRepository != null) {
-                messagesRepository.insertMessage(Long.toString(chatId), "assistant", caption);
-            }
+            messagesRepository.insertMessage(Long.toString(chatId), "assistant", caption);
             boolean deleted = tempFile.delete(); // cleanup
             if (!deleted) {
                 tempFile.deleteOnExit(); // ensure deletion on exit if immediate deletion fails

--- a/src/test/java/com/github/beothorn/telegramAIConnector/telegram/CommandsTest.java
+++ b/src/test/java/com/github/beothorn/telegramAIConnector/telegram/CommandsTest.java
@@ -2,6 +2,7 @@ package com.github.beothorn.telegramAIConnector.telegram;
 
 import com.github.beothorn.telegramAIConnector.tasks.TaskScheduler;
 import com.github.beothorn.telegramAIConnector.user.profile.UserProfileRepository;
+import com.github.beothorn.telegramAIConnector.user.MessagesRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.ToolCallbackProvider;
@@ -31,6 +32,7 @@ public class CommandsTest {
                 mock(TaskScheduler.class),
                 provider,
                 mock(UserProfileRepository.class),
+                mock(MessagesRepository.class),
                 "folder");
         String result = commands.listTools();
 

--- a/src/test/java/com/github/beothorn/telegramAIConnector/telegram/TelegramAiBotMessageHistoryTest.java
+++ b/src/test/java/com/github/beothorn/telegramAIConnector/telegram/TelegramAiBotMessageHistoryTest.java
@@ -1,0 +1,78 @@
+package com.github.beothorn.telegramAIConnector.telegram;
+
+import ai.fal.client.FalClient;
+import com.github.beothorn.telegramAIConnector.ai.AiBotService;
+import com.github.beothorn.telegramAIConnector.auth.Authentication;
+import com.github.beothorn.telegramAIConnector.tasks.TaskScheduler;
+import com.github.beothorn.telegramAIConnector.user.MessagesRepository;
+import com.github.beothorn.telegramAIConnector.user.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.ai.chat.model.ChatModel;
+import org.telegram.telegrambots.meta.api.methods.send.SendDocument;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.generics.TelegramClient;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class TelegramAiBotMessageHistoryTest {
+
+    @TempDir
+    Path tempDir;
+
+    private TelegramAiBot createBot(MessagesRepository messages, TelegramClient client) throws Exception {
+        TelegramAiBot bot = new TelegramAiBot(
+                mock(AiBotService.class),
+                mock(TaskScheduler.class),
+                mock(Authentication.class),
+                mock(UserRepository.class),
+                mock(Commands.class),
+                messages,
+                mock(ChatModel.class),
+                mock(FalClient.class),
+                new ProcessingStatus(),
+                "token",
+                tempDir.toString()
+        );
+        Field f = TelegramAiBot.class.getDeclaredField("telegramClient");
+        f.setAccessible(true);
+        f.set(bot, client);
+        return bot;
+    }
+
+    /**
+     * Asserts that plain messages are stored in history when sent.
+     */
+    @Test
+    void sendMessageStoresHistory() throws Exception {
+        MessagesRepository messages = mock(MessagesRepository.class);
+        TelegramClient client = mock(TelegramClient.class);
+        TelegramAiBot bot = createBot(messages, client);
+
+        bot.sendMessage(1L, "hi");
+
+        verify(client).execute(any(SendMessage.class));
+        verify(messages).insertMessage("1", "assistant", "hi");
+    }
+
+    /**
+     * Asserts that file captions are stored in history when sending files.
+     */
+    @Test
+    void sendFileStoresCaption() throws Exception {
+        MessagesRepository messages = mock(MessagesRepository.class);
+        TelegramClient client = mock(TelegramClient.class);
+        TelegramAiBot bot = createBot(messages, client);
+
+        File file = File.createTempFile("tmp", ".txt", tempDir.toFile());
+        bot.sendFileWithCaption(2L, file.getAbsolutePath(), "cap");
+
+        verify(client).execute(any(SendDocument.class));
+        verify(messages).insertMessage("2", "assistant", "cap");
+    }
+}


### PR DESCRIPTION
## Summary
- append a MessagesRepository to TelegramAiBot and TelegramTools
- ensure command messages are stored in history
- persist outgoing TelegramTools messages in conversation history
- inject MessagesRepository in Commands
- test new history behavior

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68546f79503c8329913a19eedba5ca2b