### PR TITLE
chore: update dependencies and fix TelegramBots 9.x build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,14 @@
 plugins {
     java
-    id("org.springframework.boot") version "3.4.4"
+    id("org.springframework.boot") version "3.5.7"
     id("io.spring.dependency-management") version "1.1.7"
     `maven-publish`
+    id("com.github.ben-manes.versions") version "0.54.0"
 }
 
 group = "com.github.beothorn"
 version = "13.0.0"
-extra["springAiVersion"] = "1.0.0-RC1"
+extra["springAiVersion"] = "1.0.3"
 
 java {
     toolchain {
@@ -34,13 +35,13 @@ dependencies {
     implementation("org.springframework.ai:spring-ai-starter-mcp-client")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
-    implementation("org.telegram:telegrambots-longpolling:8.0.0")
-    implementation("org.telegram:telegrambots-client:8.0.0")
-    implementation("org.xerial:sqlite-jdbc:3.49.1.0")
+    implementation("org.telegram:telegrambots-longpolling:9.6.0")
+    implementation("org.telegram:telegrambots-client:9.6.0")
+    implementation("org.xerial:sqlite-jdbc:3.53.1.0")
     implementation("ai.fal.client:fal-client:0.7.1")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("org.awaitility:awaitility:4.2.0")
+    testImplementation("org.awaitility:awaitility:4.3.0")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/src/main/java/com/github/beothorn/telegramAIConnector/telegram/TelegramAiBot.java
+++ b/src/main/java/com/github/beothorn/telegramAIConnector/telegram/TelegramAiBot.java
@@ -29,6 +29,7 @@ import org.telegram.telegrambots.meta.api.methods.send.SendDocument;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.*;
 import org.telegram.telegrambots.meta.api.objects.message.Message;
+import org.telegram.telegrambots.meta.api.objects.photo.PhotoSize;
 import org.telegram.telegrambots.meta.api.objects.polls.Poll;
 import org.telegram.telegrambots.meta.api.objects.polls.PollOption;
 import org.telegram.telegrambots.meta.api.objects.stickers.Sticker;


### PR DESCRIPTION
### Motivation
- Update project dependencies to recent releases and fix compilation issues caused by upstream API/package changes.

### Description
- Bumped plugin and library versions including `org.springframework.boot` to `3.5.7`, Spring AI BOM to `1.0.3`, ben-manes versions plugin to `0.54.0`, `awaitility` to `4.3.0`, TelegramBots client/longpolling to `9.6.0`, and `sqlite-jdbc` to `3.53.1.0` in `build.gradle.kts`.
- Added explicit import `org.telegram.telegrambots.meta.api.objects.photo.PhotoSize` to `TelegramAiBot.java` to address the TelegramBots 9.x packaging change that caused compilation errors.
- Updated source and build files so the project compiles against the newer dependency set.

### Testing
- Ran `./gradlew dependencyUpdates --no-daemon --console=plain` which completed and generated the dependency report.
- Ran the full test suite with `./gradlew test --no-daemon -q` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a119b82be4483298c9564fef517af72)